### PR TITLE
Fix: Error Handling in HitComponent when Hit is an Object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+.idea/

--- a/apps/website_dashboard/components/pages/dashboard/collections/collection_subroute_pages/query/hit_component.tsx
+++ b/apps/website_dashboard/components/pages/dashboard/collections/collection_subroute_pages/query/hit_component.tsx
@@ -19,7 +19,7 @@ const HitComponent = ({ hit, keys }: HitComponentProps) => {
                         <div key={index} className="flex gap-3 ">
                             <p className="font-semibold font-oswald">{field}</p>
                             <p>:</p>
-                            <p className="font-oswald">{hit[field]}</p>
+                            <p className="font-oswald">{showData(hit[field])}</p>
                         </div>
                     );
                 })}

--- a/apps/website_dashboard/components/pages/dashboard/collections/collection_subroute_pages/query/hit_component.tsx
+++ b/apps/website_dashboard/components/pages/dashboard/collections/collection_subroute_pages/query/hit_component.tsx
@@ -1,37 +1,42 @@
 import React from "react";
 
 interface HitComponentProps {
-  hit: any;
-  keys: Record<"inSchema" | "notInSchema", string[]>;
+    hit: any;
+    keys: Record<"inSchema" | "notInSchema", string[]>;
 }
-
+const showData = (data: any) => {
+    if(typeof data === "object"){
+        return JSON.stringify(data)
+    }
+    return data
+}
 const HitComponent = ({ hit, keys }: HitComponentProps) => {
-  return (
-    <div className="flex flex-col w-full gap-1 px-3 py-3 my-3 bg-[#f5f7fb] rounded-md">
-      <div>
-        {keys.notInSchema.map((field, index) => {
-          return (
-            <div key={index} className="flex gap-3 ">
-              <p className="font-semibold font-oswald">{field}</p>
-              <p>:</p>
-              <p className="font-oswald">{hit[field]}</p>
+    return (
+        <div className="flex flex-col w-full gap-1 px-3 py-3 my-3 bg-[#f5f7fb] rounded-md">
+            <div>
+                {keys.notInSchema.map((field, index) => {
+                    return (
+                        <div key={index} className="flex gap-3 ">
+                            <p className="font-semibold font-oswald">{field}</p>
+                            <p>:</p>
+                            <p className="font-oswald">{hit[field]}</p>
+                        </div>
+                    );
+                })}
             </div>
-          );
-        })}
-      </div>
-      <div>
-        {keys.inSchema.map((field, index) => {
-          return (
-            <div key={index} className="flex gap-3 ">
-              <p className="font-semibold font-oswald">{field}</p>
-              <p>:</p>
-              <p className="font-oswald">{hit[field]}</p>
+            <div>
+                {keys.inSchema.map((field, index) => {
+                    return (
+                        <div key={index} className="flex gap-3 ">
+                            <p className="font-semibold font-oswald">{field}</p>
+                            <p>:</p>
+                            <p className="font-oswald">{showData(hit[field])}</p>
+                        </div>
+                    );
+                })}
             </div>
-          );
-        })}
-      </div>
-    </div>
-  );
+        </div>
+    );
 };
 
 export default HitComponent;


### PR DESCRIPTION
This fix addresses the unhandled runtime error that occurs when objects are used as a child in React within the HitComponent. The error is specifically triggered when an object with specific keys is detected, which is not valid in React.

The solution has been implemented to ensure a collection of children is rendered using an array instead of an object. This resolves the 'Objects are not valid as a React child' error and ensures the HitComponent operates correctly when an object is hit.